### PR TITLE
fix: object store http header last modified

### DIFF
--- a/object_store/src/client/get.rs
+++ b/object_store/src/client/get.rs
@@ -49,8 +49,8 @@ impl<T: GetClient> GetClientExt for T {
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let range = options.range.clone();
         let response = self.get_request(location, options, false).await?;
-        let meta =
-            header_meta(location, response.headers()).map_err(|e| Error::Generic {
+        let meta = header_meta(location, response.headers(), Default::default())
+            .map_err(|e| Error::Generic {
                 store: T::STORE,
                 source: Box::new(e),
             })?;
@@ -73,9 +73,11 @@ impl<T: GetClient> GetClientExt for T {
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
         let options = GetOptions::default();
         let response = self.get_request(location, options, true).await?;
-        header_meta(location, response.headers()).map_err(|e| Error::Generic {
-            store: T::STORE,
-            source: Box::new(e),
+        header_meta(location, response.headers(), Default::default()).map_err(|e| {
+            Error::Generic {
+                store: T::STORE,
+                source: Box::new(e),
+            }
         })
     }
 }

--- a/object_store/src/client/header.rs
+++ b/object_store/src/client/header.rs
@@ -100,13 +100,8 @@ pub fn header_meta(
             let e_tag = e_tag.to_str().context(BadHeaderSnafu)?;
             Some(e_tag.to_string())
         }
-        None => {
-            if cfg.etag_required {
-                return Err(Error::MissingEtag);
-            } else {
-                None
-            }
-        }
+        None if cfg.etag_required => return Err(Error::MissingEtag),
+        None => None,
     };
 
     let content_length = headers

--- a/object_store/src/client/header.rs
+++ b/object_store/src/client/header.rs
@@ -86,13 +86,8 @@ pub fn header_meta(
                 .context(InvalidLastModifiedSnafu { last_modified })?
                 .with_timezone(&Utc)
         }
-        None => {
-            if cfg.last_modified_required {
-                return Err(Error::MissingLastModified);
-            } else {
-                chrono::Utc.timestamp_nanos(0)
-            }
-        }
+        None if cfg.last_modified_required => return Err(Error::MissingLastModified),
+        None => Utc.timestamp_nanos(0),
     };
 
     let e_tag = match headers.get(ETAG) {

--- a/object_store/src/client/header.rs
+++ b/object_store/src/client/header.rs
@@ -82,10 +82,9 @@ pub fn header_meta(
     let last_modified = match headers.get(LAST_MODIFIED) {
         Some(last_modified) => {
             let last_modified = last_modified.to_str().context(BadHeaderSnafu)?;
-            let last_modified = DateTime::parse_from_rfc2822(last_modified)
+            DateTime::parse_from_rfc2822(last_modified)
                 .context(InvalidLastModifiedSnafu { last_modified })?
-                .with_timezone(&Utc);
-            last_modified
+                .with_timezone(&Utc)
         }
         None => {
             if cfg.last_modified_required {

--- a/object_store/src/http/mod.rs
+++ b/object_store/src/http/mod.rs
@@ -40,7 +40,7 @@ use snafu::{OptionExt, ResultExt, Snafu};
 use tokio::io::AsyncWrite;
 use url::Url;
 
-use crate::client::header::header_meta;
+use crate::client::header::{header_meta, HeaderConfig};
 use crate::http::client::Client;
 use crate::path::Path;
 use crate::{
@@ -117,7 +117,12 @@ impl ObjectStore for HttpStore {
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
         let range = options.range.clone();
         let response = self.client.get(location, options).await?;
-        let meta = header_meta(location, response.headers()).context(MetadataSnafu)?;
+        let cfg = HeaderConfig {
+            last_modified_required: false,
+            etag_required: false,
+        };
+        let meta =
+            header_meta(location, response.headers(), cfg).context(MetadataSnafu)?;
 
         let stream = response
             .bytes_stream()


### PR DESCRIPTION
This seems to fix the issue for 
```
  2023-09-17T15:54:44.667940Z ERROR testing::slt::cli: Error while running test `sqllogictests/functions/json_scan`, error: test fail: query failed: internal error: cannot execute simple query: db error: ERROR: External error: Object Store error: Generic HTTP error: Unable to extract metadata from headers: Last-Modified Header missing from response
[SQL] select count(*) from ndjson_scan('https://raw.githubusercontent.com/GlareDB/glaredb/main/testdata/sqllogictests_datasources_common/data/bikeshare_stations.ndjson');
at /Users/sean/Code/github.com/glaredb/glaredb/testdata/sqllogictests/functions/json_scan.slt:22
```

It just sets the last_modified to the epoch if it is not available (this is what datafusion & others are doing when it's N/A. )

